### PR TITLE
Improve database caching between builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,17 +33,16 @@ dependencies:
     # Cache DB dumps directory.
     - .data
   pre:
-    # Stopping default mysql service so the db container can expose itself on port 3306.
-    - sudo service mysql stop
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
     - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
     # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
-    # Load db container image from cache directory.
+    - echo "Load db container image from cache directory"
     - docker load --input "${DB_CONTAINER_TAR}"
-    - docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"
+    - echo "replacing default mysql service with db container"
+    - sudo service mysql stop && docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"
     # Set a time zone to make sure that PHP's time functions work correctly.
     - echo "date.timezone = Australia/Sydney" >> /opt/circleci/php/$(phpenv global)/etc/php.ini
     # Disable xdebug to speed-up composer.

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,8 @@ dependencies:
     # Cache DB dumps directory.
     - .data
   pre:
+    # Stopping default mysql service so the db container can expose itself on port 3306.
+    - sudo service mysql stop
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
     - if [ ! -f $BUILD_DIR/.data/db.dist.sql ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $BUILD_DIR/.data/db.dist.sql; fi

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,8 @@ machine:
     PATH: "$HOME/.config/composer/vendor/bin:$PATH"
   hosts:
     local.mysiteurl: 127.0.0.1
+  services:
+    - docker
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -36,10 +36,10 @@ dependencies:
     - sudo service mysql stop
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
-    - if [ ! -f $BUILD_DIR/.data/db.dist.sql ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $BUILD_DIR/.data/db.dist.sql; fi
+    - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; bash <(curl -s https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff); fi
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
-    # - if [ ! -f $BUILD_DIR/.data/db.dist.sql ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $BUILD_DIR/.data/db.dist.sql; fi
+    # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff); fi
     # Set a time zone to make sure that PHP's time functions work correctly.
     - echo "date.timezone = Australia/Sydney" >> /opt/circleci/php/$(phpenv global)/etc/php.ini
     # Disable xdebug to speed-up composer.

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     BUILD_DIR: $HOME/$CIRCLE_PROJECT_REPONAME
     DB_NAME: "circle_test"
-    DB_USER: "ubuntu"
+    DB_USER: "root"
     DB_PASS: ""
     DB_HOST: "127.0.0.1"
     # Server configuration.

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     DB_HOST: "127.0.0.1"
     DB_SOURCE_DUMP: "$BUILD_DIR/.data/db.dist.sql"
     DB_CONTAINER_TAR: "$BUILD_DIR/.data/db-container.tar"
-    DB_CONTAINER_SCRIPT: "https://gist.githubusercontent.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff/raw/a1092fe8602546944aca961e83b303f95c44a9e6/db-container-build.sh"
+    DB_CONTAINER_SCRIPT: "https://goo.gl/eoeTMb"
     # Server configuration.
     SERVER: local.mysiteurl
     WEB_URL: http://local.mysiteurl

--- a/circle.yml
+++ b/circle.yml
@@ -40,6 +40,9 @@ dependencies:
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
     # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff); fi
+    # Load db container image from cache directory.
+    - docker load --input "${DB_CONTAINER_TAR}"
+    - docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"
     # Set a time zone to make sure that PHP's time functions work correctly.
     - echo "date.timezone = Australia/Sydney" >> /opt/circleci/php/$(phpenv global)/etc/php.ini
     # Disable xdebug to speed-up composer.

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     DB_PASS: ""
     DB_HOST: "127.0.0.1"
     DB_SOURCE_DUMP: "$BUILD_DIR/.data/db.dist.sql"
+    # Set to "false" to disable container-based database caching.
+    DB_CONTAINER_ENABLE: "true"
     DB_CONTAINER_TAR: "$BUILD_DIR/.data/db-container.tar"
     DB_CONTAINER_SCRIPT: "https://goo.gl/eoeTMb"
     # Server configuration.
@@ -35,14 +37,22 @@ dependencies:
   pre:
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
-    - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
+     - if [ ! -f $DB_SOURCE_DUMP ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; fi
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
-    # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
-    - echo "Load db container image from cache directory"
-    - docker load --input "${DB_CONTAINER_TAR}"
-    - echo "replacing default mysql service with db container"
-    - sudo service mysql stop && docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"
+    # - if [ ! -f $DB_SOURCE_DUMP ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; fi
+    - |
+      if [ "${DB_CONTAINER_ENABLE}" == "true" ]; then
+        if [ -f "${DB_CONTAINER_TAR}" ]; then
+          echo "Load db container image from cache directory"
+          docker load --input "${DB_CONTAINER_TAR}"
+        else
+          echo "Building database container"
+          bash <(curl -s "${DB_CONTAINER_SCRIPT}")
+        fi
+        echo "replacing default mysql service with db container"
+        sudo service mysql stop && docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"
+      fi
     # Set a time zone to make sure that PHP's time functions work correctly.
     - echo "date.timezone = Australia/Sydney" >> /opt/circleci/php/$(phpenv global)/etc/php.ini
     # Disable xdebug to speed-up composer.

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ machine:
     DB_USER: "root"
     DB_PASS: ""
     DB_HOST: "127.0.0.1"
+    DB_SOURCE_DUMP: "$BUILD_DIR/.data/db.dist.sql"
+    DB_CONTAINER_TAR: "$BUILD_DIR/.data/db-container.tar"
     # Server configuration.
     SERVER: local.mysiteurl
     WEB_URL: http://local.mysiteurl

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ machine:
     DB_HOST: "127.0.0.1"
     DB_SOURCE_DUMP: "$BUILD_DIR/.data/db.dist.sql"
     DB_CONTAINER_TAR: "$BUILD_DIR/.data/db-container.tar"
+    DB_CONTAINER_SCRIPT: "https://gist.githubusercontent.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff/raw/a1092fe8602546944aca961e83b303f95c44a9e6/db-container-build.sh"
     # Server configuration.
     SERVER: local.mysiteurl
     WEB_URL: http://local.mysiteurl
@@ -36,10 +37,10 @@ dependencies:
     - sudo service mysql stop
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
-    - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; bash <(curl -s https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff); fi
+    - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
-    # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff); fi
+    # - if [ ! -f "${DB_CONTAINER_TAR}" ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; bash <(curl -s "${DB_CONTAINER_SCRIPT}"); fi
     # Load db container image from cache directory.
     - docker load --input "${DB_CONTAINER_TAR}"
     - docker run -d -p 3306:3306 "mysql/${DB_NAME}:latest"

--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,7 @@ dependencies:
   pre:
     # Download DB dump from public URL to test Drupal-dev project.
     # Remove the line below in your project.
-     - if [ ! -f $DB_SOURCE_DUMP ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; fi
+    - if [ ! -f $DB_SOURCE_DUMP ] ; then mkdir $BUILD_DIR/.data && curl -L https://goo.gl/WFtJbT -o $DB_SOURCE_DUMP; fi
     # [META] Uncomment the line below to download DB dump from FTP, using
     # variables set in Circle CI UI.
     # - if [ ! -f $DB_SOURCE_DUMP ] ; then mkdir $BUILD_DIR/.data && curl -u $FTP_USER:$FTP_PASS "ftp://$FTP_HOST/db_d7.dist.sql" -o $DB_SOURCE_DUMP; fi

--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,8 @@
       "@build"
     ],
     "build-db": [
+      "drush @local.mysiteurl sql-drop -y",
+      "drush @local.mysiteurl sql-cli < .data/db.dist.sql",
       "drush @local.mysiteurl en mysite_core -y",
       "drush @local.mysiteurl updb -y"
     ],

--- a/composer.json
+++ b/composer.json
@@ -107,8 +107,6 @@
       "@build"
     ],
     "build-db": [
-      "drush @local.mysiteurl sql-drop -y",
-      "drush @local.mysiteurl sql-cli < .data/db.dist.sql",
       "drush @local.mysiteurl en mysite_core -y",
       "drush @local.mysiteurl updb -y"
     ],

--- a/composer.json
+++ b/composer.json
@@ -107,8 +107,8 @@
       "@build"
     ],
     "build-db": [
-      "drush @local.mysiteurl sql-drop -y",
-      "drush @local.mysiteurl sql-cli < .data/db.dist.sql",
+      "if [ \"$DB_CONTAINER_ENABLE\" != \"true\" ]; then drush @local.mysiteurl sql-drop -y; fi",
+      "if [ \"$DB_CONTAINER_ENABLE\" != \"true\" ]; then drush @local.mysiteurl sql-cli < .data/db.dist.sql; fi",
       "drush @local.mysiteurl en mysite_core -y",
       "drush @local.mysiteurl updb -y"
     ],


### PR DESCRIPTION
Fixes #3 

## What does this PR do?

* Disables the default CircleCI mysql service and replaces with a docker container running mysql.
* Adds a command to database fetch step which executes a remote bash script. This bash script builds a container image with the database pre-loaded.
* Adds some environment variables to support this script.
* Removed 2 build steps from `composer.json` which dropped and re-imported the database dump. (note: this may need further input to accommodate local dev).

## Where should the reviewer start?

* Review the db container image build script - https://gist.github.com/nicksantamaria/43f44c45ac2cb31298cacd5c546902ff
* Review new environment variables in `circle.yml`
* Ensure workflow meets requirements.

## Background

The high-level approach for this feature was described in #3, however there were several implementation details which lead to this end result.

* The docker project are vehemently against Dockerfiles which rely on host-specific contexts. This killed the idea to have a `drupal-dev-containers` repo hosting the Dockerfiles, as the database dump needs to exist in the same directory at runtime. This was problematic as the process needed to be flexible enough for the db dump to be sourced in any number of ways (rsync, ftp, http etc..) and we do not want to have to support and maintain all those methods.
* The next idea to have a `docker run` >> `docker exec` >> `docker export` did not work as expected, as the exported "image" did not have all of the configuration provided by the base image `Dockerfile` (`ENV`, `ENTRYPOINT` etc..)
* The end solution was an evolution of the original idea, but with a dynamically generated Dockerfile. This means that the end-user can fetch the db dump however they wish, as long as it is stored in the right location prior to the db container being built.

## Anything else?

* As noted above, I removed a few lines from composer.json which will affect local dev. Looking for advice on best approach here.
* Once happy with the container build bash script, it should be moved to the `integratedexperts` namespace, and the location updated in this branch.