### PR TITLE
[8.x] Fixed whitelisting of scaffold files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,7 @@ docroot/profiles/*
 docroot/sites/default/*
 !docroot/sites/default/settings.php
 !docroot/sites/default/services.yml
-
-#; Whitelist scaffold files. @see https://github.com/drupal-composer/drupal-scaffold#limitation
-#; Note that consumer sites will only need to whitelist and commit these files
-#; in case if they need to change them. For example, robots.txt must be whitelisted
-#; and committed if it has custom entries.
-#;< DRUPAL-DEV
+# Whitelist scaffold files. @see https://github.com/drupal-composer/drupal-scaffold#limitation
 !docroot/.editorconfig
 !docroot/.eslintignore
 !docroot/.gitattributes
@@ -34,7 +29,8 @@ docroot/sites/default/*
 !docroot/index.php
 !docroot/robots.txt
 !docroot/update.php
-# Do not ignore this file in Drupal-Dev itself, but keep ignoring in consumer site.
+#;< DRUPAL-DEV
+#; Do not ignore these files in Drupal-Dev itself, but keep ignoring in consumer site.
 !docroot/sites/default/default.settings.local.php
 !docroot/sites/default/default.services.local.yml
 #;> DRUPAL-DEV

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
                 ".editorconfig",
                 ".eslintignore",
                 ".gitattributes",
+                "autoload.php",
                 "index.php",
                 "robots.txt",
                 "update.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23964092b31fea986d4ef141e60fe8f0",
+    "content-hash": "b26fab11eb7c4483efa69e14a4a9b1bb",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/tests/bats/install_existing.bats
+++ b/tests/bats/install_existing.bats
@@ -195,7 +195,6 @@ load test_helper_drupaldev
 
   install_dependencies_stub "${CURRENT_PROJECT_DIR}"
 
-  # Commit files required to run the project.
   git_add_all_commit "${CURRENT_PROJECT_DIR}" "Init Drupal-Dev"
 
   # Assert that custom file preserved.
@@ -250,12 +249,7 @@ load test_helper_drupaldev
 
   install_dependencies_stub "${CURRENT_PROJECT_DIR}"
 
-  # Commit files required to run the project.
-  git_add "${CURRENT_PROJECT_DIR}" README.md
-  git_add "${CURRENT_PROJECT_DIR}" .circleci/config.yml
-  git_add "${CURRENT_PROJECT_DIR}" docroot/sites/default/settings.php
-  git_add "${CURRENT_PROJECT_DIR}" docroot/sites/default/services.yml
-  git_commit "${CURRENT_PROJECT_DIR}" "Init Drupal-Dev"
+  git_add_all_commit "${CURRENT_PROJECT_DIR}" "Init Drupal-Dev"
 
   # Assert that custom file preserved.
   assert_file_exists "${CURRENT_PROJECT_DIR}/test1.txt"

--- a/tests/bats/test_helper_drupaldev.bash
+++ b/tests/bats/test_helper_drupaldev.bash
@@ -226,16 +226,6 @@ assert_files_not_present_common(){
   assert_file_not_exists "docroot/modules/custom/your_site_core/tests/src/Unit/YourSiteCoreHelperUnitTest.php"
   assert_file_not_exists "docroot/modules/custom/your_site_core/tests/src/Unit/YourSiteCoreUnitTestCase.php"
 
-  # Scaffolding files exist.
-  assert_file_not_exists "docroot/.editorconfig"
-  assert_file_not_exists "docroot/.eslintignore"
-  assert_file_not_exists "docroot/.gitattributes"
-  assert_file_not_exists "docroot/.htaccess"
-  assert_file_not_exists "docroot/autoload.php"
-  assert_file_not_exists "docroot/index.php"
-  assert_file_not_exists "docroot/robots.txt"
-  assert_file_not_exists "docroot/update.php"
-
   assert_file_not_exists "FAQs.md"
   assert_file_not_exists ".ahoy.yml"
 
@@ -244,11 +234,29 @@ assert_files_not_present_common(){
     assert_file_exists ".circleci/config.yml"
     assert_file_exists "docroot/sites/default/settings.php"
     assert_file_exists "docroot/sites/default/services.yml"
+    # Scaffolding files exist.
+    assert_file_exists "docroot/.editorconfig"
+    assert_file_exists "docroot/.eslintignore"
+    assert_file_exists "docroot/.gitattributes"
+    assert_file_exists "docroot/.htaccess"
+    assert_file_exists "docroot/autoload.php"
+    assert_file_exists "docroot/index.php"
+    assert_file_exists "docroot/robots.txt"
+    assert_file_exists "docroot/update.php"
   else
     assert_file_not_exists "README.md"
     assert_file_not_exists ".circleci/config.yml"
     assert_file_not_exists "docroot/sites/default/settings.php"
     assert_file_not_exists "docroot/sites/default/services.yml"
+    # Scaffolding files not exist.
+    assert_file_not_exists "docroot/.editorconfig"
+    assert_file_not_exists "docroot/.eslintignore"
+    assert_file_not_exists "docroot/.gitattributes"
+    assert_file_not_exists "docroot/.htaccess"
+    assert_file_not_exists "docroot/autoload.php"
+    assert_file_not_exists "docroot/index.php"
+    assert_file_not_exists "docroot/robots.txt"
+    assert_file_not_exists "docroot/update.php"
   fi
 
   popd > /dev/null || exit 1

--- a/tests/bats/test_helper_drupaldev.bash
+++ b/tests/bats/test_helper_drupaldev.bash
@@ -234,15 +234,6 @@ assert_files_not_present_common(){
     assert_file_exists ".circleci/config.yml"
     assert_file_exists "docroot/sites/default/settings.php"
     assert_file_exists "docroot/sites/default/services.yml"
-    # Scaffolding files exist.
-    assert_file_exists "docroot/.editorconfig"
-    assert_file_exists "docroot/.eslintignore"
-    assert_file_exists "docroot/.gitattributes"
-    assert_file_exists "docroot/.htaccess"
-    assert_file_exists "docroot/autoload.php"
-    assert_file_exists "docroot/index.php"
-    assert_file_exists "docroot/robots.txt"
-    assert_file_exists "docroot/update.php"
   else
     assert_file_not_exists "README.md"
     assert_file_not_exists ".circleci/config.yml"


### PR DESCRIPTION
Fixes an issue where scaffold files (`docroot/index.php` etc) are not explicitly whitelisted in `.gitignore` when the stack is installed.